### PR TITLE
Add two datetime methods notebooks

### DIFF
--- a/python_for_analytics/notebooks/datetime/working_with_datetime_objects_pt_1.ipynb
+++ b/python_for_analytics/notebooks/datetime/working_with_datetime_objects_pt_1.ipynb
@@ -1,0 +1,394 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Types: all objects in python have a type. You can check the type by using the _type()_ function. Here are a few standard ones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(1.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type('abc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### You can convert between types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "str(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int('9')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int(9.9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrames also have a type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents = pd.read_csv('data/Traffic_Accidents__2019_.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "type(accidents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### And each column has a type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "accidents.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### One data type you will encounter is a `datetime`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The `Date and Time` column in the `accidents` dataframe is treated as an `object` but we can convert it to a different type, such as a `datetime` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's convert the 'Date and Time' column to a datetime and assign it back to itself\n",
+    "accidents['Date and Time'] = pd.to_datetime(accidents['Date and Time'])\n",
+    "\n",
+    "# pd.to_datetime will infer the different date and time components of the string.\n",
+    "# If the datetime is in a strange format or you want to be explicit you can use the 'format' argument\n",
+    "# You will have to use datetime symbols: \n",
+    "# https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior\n",
+    "\n",
+    "# It will take a second to run..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now the column is a datetime64[ns]\n",
+    "accidents.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The values in the Date and Time column look different now\n",
+    "accidents.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# And we can see each value is a timestamp\n",
+    "accidents.loc[0, 'Date and Time']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Once you have a `datetime` object, you can pull out [individual parts](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.dt.html)\n",
+    "- Use `.dt` to specify a datetime attribute/function and then what you want to pull out\n",
+    "- Pull out the month from the 'Date and Time' column and save it to a new column called 'month'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents['month'] = accidents['Date and Time'].dt.month\n",
+    "accidents.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### What is the maximum number of cars involved in a single accident in July?\n",
+    "- subset the `accidents` DataFrame to get the July accidents\n",
+    "- find the maximum `Number of Motor Vehicles` for accidents that happened in July\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "july_accidents = accidents[accidents['month']==7]\n",
+    "july_accidents.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "july_accidents['Number of Motor Vehicles'].max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "july_accidents.nlargest(1, 'Number of Motor Vehicles')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How many accidents happened in December?\n",
+    "(accidents['month']==12).sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### There are [many different attributes associated with datetimes](https://towardsdatascience.com/working-with-datetime-in-pandas-dataframe-663f7af6c587)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents['Date and Time'].dt.time.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents['Date and Time'].dt.date.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents['Date and Time'].dt.weekday.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents['Date and Time'].dt.is_leap_year.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### You can use comparison symbols on `datetime` objects as well"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How many accidents happened before March 3\n",
+    "sum(accidents['Date and Time'] < '03/03/2019')\n",
+    "\n",
+    "# Note: You have to input the comparison value as a string,\n",
+    "# but the format can vary and pandas will attempt to infer the format.\n",
+    "# Try putting in different formats and rerunning this cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### You can also perform calculations on `datetime` objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How long between the 1st and 101th accident?\n",
+    "accidents = accidents.sort_values('Date and Time')\n",
+    "accidents.loc[100, 'Date and Time'] - accidents.loc[0, 'Date and Time']\n",
+    "\n",
+    "# It appears as a Timedelta, or a change in time"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python_for_analytics/notebooks/datetime/working_with_datetime_objects_pt_2.ipynb
+++ b/python_for_analytics/notebooks/datetime/working_with_datetime_objects_pt_2.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents = pd.read_csv('data/Traffic_Accidents__2019_.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's convert the Date and Time column to the datetime type. To save time, we can specify the format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents['Date and Time'] = pd.to_datetime(accidents['Date and Time'], format = '%m/%d/%Y %I:%M:%S %p')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once we have it in datetime format it becomes easy to answer questions like \"How many accidents were there per month?\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(accidents\n",
+    " .assign(month = accidents['Date and Time'].dt.month_name())\n",
+    " .month\n",
+    " .value_counts(sort = False)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at how the number of accidents vary by hour of the day.\n",
+    "\n",
+    "One method we could try is to extract out the date and hour portions and do a `groupby` + `count`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(accidents\n",
+    " .assign(date = accidents['Date and Time'].dt.date, \n",
+    "         hour = accidents['Date and Time'].dt.hour)     # Create a date and hour column so that we can group\n",
+    " .groupby(['date', 'hour'])\n",
+    " ['Accident Number']\n",
+    " .count()\n",
+    " .reset_index()\n",
+    " .head(10)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is a big problem with this, which can be seen if you look carefully at the output above. There are no rows for 6:00, 7:00, or 8:00 on January 1. This is because there were no accidents during these hours, so there were no rows to count.\n",
+    "\n",
+    "A better method (and one that will require less work to pull off) is to use a `Grouper` to group by hour."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(accidents\n",
+    " .groupby(pd.Grouper(key = 'Date and Time',     # point it to your datetime column\n",
+    "                     freq = '1h',               # How much do you want to group together values?\n",
+    "                     origin = 'epoch'           # This will start times at midnight of 1970-01-01. This ensure\n",
+    "                                                # This ensures that we are starting our first grouped period on the hour\n",
+    "                    ))\n",
+    " ['Accident Number']\n",
+    " .count()\n",
+    " .reset_index()\n",
+    " .head(10)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Late night on November 11, 2019 [Nashville received a rare November snow](https://fox17.com/news/local/nws-nashville-sees-rare-early-november-snow). Let's investigate to see if we can detect any effect on the number of accidents the following morning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, filter down to the following day\n",
+    "snow_day = accidents[(accidents['Date and Time'] >= '2019-11-12') & \n",
+    "                     (accidents['Date and Time'] < '2019-11-13')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's apply a grouper to the our snow day."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(snow_day\n",
+    " .groupby(pd.Grouper(key = 'Date and Time',\n",
+    "                     freq = '1h',\n",
+    "                     origin = 'epoch'\n",
+    "                    ))\n",
+    " ['Accident Number']\n",
+    " .count()\n",
+    " .plot(figsize = (10,5))\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It does look like there were quite a few accidents in the morning, but in isolation, it is hard to know if what we are seeing is unusual. Let's do a comparison with the rest of the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents_grouped = (accidents\n",
+    "                     .assign(weekday = accidents['Date and Time'].dt.day_name())\n",
+    "                     .query('weekday != \"Saturday\" and weekday != \"Sunday\"')   # remove the weekends\n",
+    "                     .groupby(pd.Grouper(key = 'Date and Time',\n",
+    "                                         freq = '1h',\n",
+    "                                         origin = 'epoch'\n",
+    "                                        ))\n",
+    " ['Accident Number']\n",
+    " .count()\n",
+    " .reset_index()       # convert the Date and Time column back to a regular column\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(accidents_grouped\n",
+    " .assign(hour = accidents_grouped['Date and Time'].dt.hour)\n",
+    " .groupby('hour')\n",
+    " ['Accident Number']\n",
+    " .agg(['mean', 'std', 'median','max'])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From this, we can see that in the morning, the 7:00 hour is usually the worst, with an average of more than 5 accidents.\n",
+    "\n",
+    "Looking back at the snow day, we can see that while the morning hours did have a high number of crashes, none of them were the worst that occurred in 2019.\n",
+    "\n",
+    "However, together the hours or 6, 7, 8, and 9 all had above-average number of crashes. Maybe we can compare this block of time to this block of time across the whole dataset.\n",
+    "\n",
+    "One way to accomplish this is to change our grouping frequency to 4 hours. Note that we also need to adjust the origin value so that 6:00 - 10:00 get grouped together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snow_day.groupby(pd.Grouper(key = 'Date and Time',     \n",
+    "                                     freq = '4h',               \n",
+    "                                     origin = '2018-12-31 02:00:00'  # This will result in the 6:00 AM - 10:00 AM times to be grouped together           \n",
+    "                           ))['Date and Time'].count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's also regroup the full dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accidents_grouped = (accidents\n",
+    "                     .assign(weekday = accidents['Date and Time'].dt.day_name())\n",
+    "                     .query('weekday != \"Saturday\" and weekday != \"Sunday\"')\n",
+    "                     .groupby(pd.Grouper(key = 'Date and Time',     \n",
+    "                                     freq = '4h',               \n",
+    "                                     origin = '2018-12-31 02:00:00'                                      \n",
+    "                                    ))\n",
+    " ['Accident Number']\n",
+    " .count()\n",
+    " .reset_index()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(accidents_grouped\n",
+    " .assign(hour = accidents_grouped['Date and Time'].dt.hour)\n",
+    " .groupby('hour')\n",
+    " ['Accident Number']\n",
+    " .agg(['mean', 'std', 'median', 'max'])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Comparing the snow day to the overall average for the 4 hour period starting at 6:00 AM, we can see that there were an above-average number of accidents. It wasn't the worst day in the whole year, but let's investigate and see where it lands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(accidents_grouped\n",
+    " .assign(hour = accidents_grouped['Date and Time'].dt.hour,\n",
+    "         weekday = accidents_grouped['Date and Time'].dt.day_name())\n",
+    " .query('hour == 6')\n",
+    " .nlargest(5, 'Accident Number')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This day was the worst Tuesday in 2019, and is tied for the 4th worst day in the whole year."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This includes two notebooks to show students how they can make use of pandas datetime methods.
The first notebook is the datetime notebook used in the jumpstart with some minor modifications. The second one is new but uses the same dataset and shows how to use pd.Grouper. I think these two notebooks can lead into the rolling windows material we already have in the event that a partner project would require use of rolling windows.